### PR TITLE
Fix resolutions

### DIFF
--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -19,5 +19,5 @@ resolve(box::AbsoluteBox, x::Min) = min(resolve(box, x.a), resolve(box, x.b))
 resolve(box::AbsoluteBox, x::Max) = max(resolve(box, x.a), resolve(box, x.b))
 resolve(box::AbsoluteBox, p::Vec) = map(x -> resolve(box, x), p) + box.x0
 resolve(outer::AbsoluteBox, box::BoundingBox) =
-    BoundingBox(resolve(outer, box.x0), map(x -> resolve(outer, x)*mm, box.a))
+    BoundingBox(resolve(outer, box.x0), map(x -> resolve(outer, x), box.a))
 

--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -17,7 +17,7 @@ resolve(box::AbsoluteBox, x::Mul) = resolve(box, x.a) * x.b
 resolve(box::AbsoluteBox, x::Div) = resolve(box, x.a) / x.b
 resolve(box::AbsoluteBox, x::Min) = min(resolve(box, x.a), resolve(box, x.b))
 resolve(box::AbsoluteBox, x::Max) = max(resolve(box, x.a), resolve(box, x.b))
-resolve(box::AbsoluteBox, p::Vec) = map(x -> resolve(box, x)*mm, p.x) + box.x0
+resolve(box::AbsoluteBox, p::Vec) = map(x -> resolve(box, x), p) + box.x0
 resolve(outer::AbsoluteBox, box::BoundingBox) =
     BoundingBox(resolve(outer, box.x0), map(x -> resolve(outer, x)*mm, box.a))
 


### PR DESCRIPTION
The change in resolving lengths w.r.t to a box to return a length and not its value meant that the extra *mm gives an error in the resolution of
- a vector w.r.t a box
- a box w.r.t an absolute outer box

Also removed the reference to the x field from the previous definition of Point. Vec types don't have the x field but are the tuples themselves!
