### PR TITLE
if you use Compat, it needs to go in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat 0.7.15


### PR DESCRIPTION
you can't assume anything will be present that you don't explicitly list
