### PR TITLE
Prevent invalid bounding box constructors

### DIFF
--- a/src/boundingbox.jl
+++ b/src/boundingbox.jl
@@ -5,10 +5,10 @@ immutable BoundingBox{P1 <: Vec, P2 <: Vec}
     a::P2
 end
 
-BoundingBox{P <: Vec, T1 <: Measure, T2 <: Measure}(x0::P, width::T1, height::T2) =
+BoundingBox{P <: Vec2, T1 <: Measure, T2 <: Measure}(x0::P, width::T1, height::T2) =
     BoundingBox{P, Tuple{T1, T2}}(x0, (width, height))
 
-BoundingBox{P <: Vec, T1 <: Measure, T2 <: Measure, T3 <: Measure}(x0::P, width::T1, height::T2, depth::T3) =
+BoundingBox{P <: Vec3, T1 <: Measure, T2 <: Measure, T3 <: Measure}(x0::P, width::T1, height::T2, depth::T3) =
     BoundingBox{P, Tuple{T1, T2, T3}}(x0, (width, height, depth))
 
 #BoundingBox{X}(x0::Vec{2, X}, width::Measure, height::Measure) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,15 @@ const rmm = Length(:mm, 1//1)
 
 const xx = Length(:xx, 1.0)
 
+facts("Bounding boxes") do
+    context("Invalid bounding box constructors") do
+        @fact_throws MethodError BoundingBox((0mm,), 1mm, 2mm)
+        @fact_throws MethodError BoundingBox((0mm, 3mm, 8mm), 1mm, 4mm)
+        @fact_throws MethodError BoundingBox((0mm, 3mm), 1mm, 2mm, 4mm)
+        @fact_throws MethodError BoundingBox((0mm, 6mm, 3mm, 8mm), 1mm, 2mm, 4mm)
+    end
+end
+
 facts("Measure constructors") do
     context("Length constructor") do
         @fact Length(:mm, 1) --> Length{:mm, Int}(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,13 @@ const rmm = Length(:mm, 1//1)
 const xx = Length(:xx, 1.0)
 
 facts("Bounding boxes") do
+    context("Valid bounding box constructors") do
+        @fact BoundingBox((0mm, 1mm), 1mm, 2mm) -->
+            BoundingBox((0mm, 1mm), 1mm, 2mm)
+        @fact BoundingBox((2mm, 1mm, 3mm), 1mm, 2mm, 4mm) -->
+            BoundingBox((2mm, 1mm, 3mm), 1mm, 2mm, 4mm) 
+    end
+
     context("Invalid bounding box constructors") do
         @fact_throws MethodError BoundingBox((0mm,), 1mm, 2mm)
         @fact_throws MethodError BoundingBox((0mm, 3mm, 8mm), 1mm, 4mm)


### PR DESCRIPTION
Fixes these newly added tests:

``` julia
facts("Bounding boxes") do
    context("Invalid bounding box constructors") do
        @fact_throws MethodError BoundingBox((0mm,), 1mm, 2mm)
        @fact_throws MethodError BoundingBox((0mm, 3mm, 8mm), 1mm, 4mm)
        @fact_throws MethodError BoundingBox((0mm, 3mm), 1mm, 2mm, 4mm)
        @fact_throws MethodError BoundingBox((0mm, 6mm, 3mm, 8mm), 1mm, 2mm, 4mm)
    end
end
```

This PR prevents construction of some invalid types of bounding boxes.
