### PR TITLE
oneunit and isabsolute for Length types

### DIFF
--- a/src/Measures.jl
+++ b/src/Measures.jl
@@ -2,7 +2,8 @@ module Measures
 
 export Measure, Length, AbsoluteLength, BoundingBox, AbsoluteBox, Absolute2DBox,
        Absolute3DBox, Vec, Vec2, Vec3, AbsoluteVec, AbsoluteVec2, AbsoluteVec3,
-       resolve, mm, cm, inch, pt, width, height
+       isabsolute, resolve,
+        mm, cm, inch, pt, width, height
 
 abstract type Measure end
 

--- a/src/length.jl
+++ b/src/length.jl
@@ -32,6 +32,9 @@ iszero(x::Length) = x.value == 0.0
 
 Base.abs(a::T) where {T <: Length} = T(abs(a.value))
 Base.isless(a::Length{U}, b::Length{U}) where U = a.value < b.value
+Base.oneunit(a::Type{Length{U,T}}) where {U,T} = Length(U, one(T))
+
+isabsolute(::Type{Length{U,T}}) where {U,T} = !in(U, [:w,:h])
 
 
 # Constants

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,4 +85,9 @@ end
         a = [1mm, 2mm, 3mm]
         @test all((a .+ 1mm) .== [2mm, 3mm, 4mm])
     end
+
+    @testset "Length methods" begin
+        @test oneunit(Length{:mm, Int}) == 1mm
+        @test !isabsolute(Length{:w, Float32})
+    end
 end


### PR DESCRIPTION
 - [x] I've added and/or updated the unit tests
 - [x] I've run the unit tests
 - [x] I've built the Compose docs (with this PR) - no errors.

### This PR
- extends functions `oneunit` and `isabsolute` for Length types
- needed for GiovineItalia/Gadfly.jl#1358
