### PR TITLE
Implement a 2-arg Base.hash() instead of 1-arg

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,24 +25,16 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/length.jl
+++ b/src/length.jl
@@ -16,7 +16,7 @@ Base.convert(::Type{Length{U, T1}}, x::Length{U, T2}) where {U, T1 <: Number, T2
 
 ==(x::Length{U}, y::Length{U}) where U = x.value == y.value
 Base.isequal(x::Length{U}, y::Length{U}) where U = isequal(x.value, y.value)
-Base.hash(x::Length{U}) where U = hash(x.value, hash(U))
+Base.hash(x::Length{U}, h::UInt) where U = hash(hash(x.value, hash(U)), h)
 
 # Operations
 # ----------


### PR DESCRIPTION
This prevents a ton of invalidations:
```julia
 inserting hash(x::Measures.Length{U}) where U @ Measures ~/.julia/packages/Measures/PKOxJ/src/length.jl:19 invalidated:                                                                                                                       
   backedges: 1: superseding hash(x) @ Base hashing.jl:28 with MethodInstance for hash(::Any) (1202 children)
```

Discovered when looking into https://github.com/JuliaLang/IJulia.jl/issues/1208.

CC @t-bltg, this is a dependency of Plots.jl.